### PR TITLE
fix(ui): fix navbar layout after bootstrap 4.1.3 upgrade

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9603,14 +9603,6 @@
         "prop-types": "15.6.2"
       }
     },
-    "react-input-autosize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
-      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
-      "requires": {
-        "prop-types": "15.6.2"
-      }
-    },
     "react-input-range": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-input-range/-/react-input-range-1.3.0.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,6 @@
     "react-autosuggest": "^9.3.4",
     "react-dom": "^16.4.1",
     "react-highlighter": "^0.4.2",
-    "react-input-autosize": "^2.2.1",
     "react-input-range": "^1.3.0",
     "react-linkify": "^0.2.2",
     "react-masonry-infinite": "^1.2.2",

--- a/ui/src/Components/MainModal/index.js
+++ b/ui/src/Components/MainModal/index.js
@@ -76,7 +76,7 @@ const MainModal = observer(
 
       return (
         <React.Fragment>
-          <ul className="navbar-nav">
+          <ul className="navbar-nav float-right">
             <li className="nav-item dropdown">
               <a
                 className="nav-link mx-1 cursor-pointer"

--- a/ui/src/Components/NavBar/FilterInput/index.css
+++ b/ui/src/Components/NavBar/FilterInput/index.css
@@ -1,8 +1,9 @@
-.components-filterinput {
+.form-control.components-filterinput {
   cursor: text;
+  height: auto;
 }
 
-.components-filterinput-wrapper > input {
+input.components-filterinput-wrapper {
   border: none;
   box-shadow: none;
   outline: none;

--- a/ui/src/Components/NavBar/FilterInput/index.js
+++ b/ui/src/Components/NavBar/FilterInput/index.js
@@ -8,7 +8,6 @@ import { debounce } from "lodash";
 
 import Autosuggest from "react-autosuggest";
 import Highlight from "react-highlighter";
-import AutosizeInput from "react-input-autosize";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons/faSearch";
@@ -132,7 +131,7 @@ const FilterInput = observer(
                 filter={filter}
               />
             ))}
-            <AutosizeInput
+            <input
               className="components-filterinput-wrapper"
               placeholder=""
               {...otherProps}
@@ -152,7 +151,7 @@ const FilterInput = observer(
         // data-filters is there to register filters for observation in mobx
         // in order to re-render input component
         <form
-          className="form-inline w-100"
+          className="form-inline mw-100"
           onSubmit={this.onSubmit}
           data-filters={alertStore.filters.values.map(f => f.raw).join(" ")}
         >

--- a/ui/src/Components/NavBar/index.js
+++ b/ui/src/Components/NavBar/index.js
@@ -28,17 +28,17 @@ const NavBar = observer(
       const { alertStore, settingsStore } = this.props;
       return (
         <div className="container">
-          <nav className="navbar fixed-top navbar-expand navbar-dark p-1 bg-primary-transparent">
+          <nav className="navbar fixed-top navbar-expand navbar-dark p-1 bg-primary-transparent d-inline-block">
             <ReactResizeDetector handleHeight onResize={navbarResize} />
-            <span className="navbar-brand my-0 mx-2 h1 d-none d-sm-block">
+            <span className="navbar-brand my-0 mx-2 h1 d-none d-sm-block float-left">
               {alertStore.info.totalAlerts}
               <FetchIndicator status={alertStore.status.value.toString()} />
             </span>
+            <MainModal alertStore={alertStore} settingsStore={settingsStore} />
             <FilterInput
               alertStore={alertStore}
               settingsStore={settingsStore}
             />
-            <MainModal alertStore={alertStore} settingsStore={settingsStore} />
           </nav>
         </div>
       );


### PR DESCRIPTION
Bootstrap 4.1.3 introduced some changes that caused issues with browser rendering of the input bar, drop autosize component as it's not needed and add classes to ensure that we order elements correctly and that the input can grow correctly if needed